### PR TITLE
Use AT+CGPADDR=1 command instead of AT+CGPADDR for check own IP

### DIFF
--- a/connectivity_diagnostics_for_lte_m_shield/connectivity_diagnostics_for_lte_m_shield.ino
+++ b/connectivity_diagnostics_for_lte_m_shield/connectivity_diagnostics_for_lte_m_shield.ino
@@ -85,8 +85,8 @@ void showNetworkInformation() {
   res = executeAT(F("+COPS?"), 300);
   CONSOLE.println(res);
   
-  CONSOLE.println(F("> AT+CGPADDR"));
-  res = executeAT(F("+CGPADDR"), 300);
+  CONSOLE.println(F("> AT+CGPADDR=1"));
+  res = executeAT(F("+CGPADDR=1"), 300);
   CONSOLE.println(res);
 }
 


### PR DESCRIPTION
自デバイスのIPアドレスチェックに `AT+CGPADDR=1` を使用するように変更しました。