### PR TITLE
Support DHT20 sensor

### DIFF
--- a/send_multiple_sensor_data_with_soracom/send_multiple_sensor_data_with_soracom.ino
+++ b/send_multiple_sensor_data_with_soracom/send_multiple_sensor_data_with_soracom.ino
@@ -29,8 +29,8 @@ TinyGsm modem(LTE_M_shieldUART);
 TinyGsmClient ctx(modem);
 
 #include <DHT.h>
-//#define USE_DHT11 // Use DHT11 (Blue)
-#define USE_DHT20 // Use DHT20 (Black)
+#define USE_DHT11 // Use DHT11 (Blue)
+// #define USE_DHT20 // Use DHT20 (Black)
 
 #ifdef USE_DHT11
   #define dht11Pin 3

--- a/send_multiple_sensor_data_with_soracom/send_multiple_sensor_data_with_soracom.ino
+++ b/send_multiple_sensor_data_with_soracom/send_multiple_sensor_data_with_soracom.ino
@@ -33,12 +33,17 @@ U8X8_SSD1306_128X64_NONAME_HW_I2C u8x8(/* clock=*/ SCL, /* data=*/ SDA, /* reset
 #define U8X8_ENABLE_180_DEGREE_ROTATION 1
 
 #include <DHT.h>
-#define dht11Pin 3
-DHT dht(dht11Pin, DHT11);
+//#define USE_DHT11 // Use DHT11 (Blue)
+#define USE_DHT20 // Use DHT20 (Black)
 
-#define OLED_MAX_CHAR_LENGTH 16
-void drawText(U8X8* u8x8, const char* in_str, int width = OLED_MAX_CHAR_LENGTH);
-void drawText_P(U8X8* u8x8, const char* pgm_s, int width = OLED_MAX_CHAR_LENGTH);
+#ifdef USE_DHT11
+  #define dht11Pin 3
+  DHT dht(dht11Pin, DHT11);
+#endif
+#ifdef USE_DHT20
+  #include <Wire.h>
+  DHT dht(DHT20);
+#endif
 
 #include <Seeed_BMP280.h>
 BMP280 bmp280;
@@ -112,6 +117,10 @@ void setup() {
   sprintf_P(ip_addr_buf, PSTR("%d.%d.%d.%d"), ipaddr[0], ipaddr[1], ipaddr[2], ipaddr[3]);
   drawText(&u8x8, ip_addr_buf);
   delay(2000);
+
+  #ifdef USE_DHT20
+  Wire.begin();
+  #endif
 
   dht.begin();
   bmp280.init();

--- a/send_multiple_sensor_data_with_soracom/send_multiple_sensor_data_with_soracom.ino
+++ b/send_multiple_sensor_data_with_soracom/send_multiple_sensor_data_with_soracom.ino
@@ -29,8 +29,9 @@ TinyGsm modem(LTE_M_shieldUART);
 TinyGsmClient ctx(modem);
 
 #include <DHT.h>
-#define USE_DHT11 // Use DHT11 (Blue)
-// #define USE_DHT20 // Use DHT20 (Black)
+
+//#define USE_DHT11 // Use DHT11 (Blue)
+#define USE_DHT20 // Use DHT20 (Black)
 
 #ifdef USE_DHT11
   #define dht11Pin 3

--- a/send_multiple_sensor_data_with_soracom/send_multiple_sensor_data_with_soracom.ino
+++ b/send_multiple_sensor_data_with_soracom/send_multiple_sensor_data_with_soracom.ino
@@ -12,7 +12,7 @@
 #define INTERVAL_MS (60000)
 #define ENDPOINT "uni.soracom.io"
 #define SKETCH_NAME "send_multiple_sensor_data_with_soracom"
-#define VERSION "1.0"
+#define VERSION "1.1"
 
 /* for LTE-M Shield for Arduino */
 #define RX 10

--- a/send_temp_and_humi_with_soracom/send_temp_and_humi_with_soracom.ino
+++ b/send_temp_and_humi_with_soracom/send_temp_and_humi_with_soracom.ino
@@ -33,8 +33,9 @@ U8X8_SSD1306_128X64_NONAME_HW_I2C u8x8(/* clock=*/ SCL, /* data=*/ SDA, /* reset
 #define U8X8_ENABLE_180_DEGREE_ROTATION 1
 
 #include <DHT.h>
-#define USE_DHT11 // Use DHT11 (Blue)
-//#define USE_DHT20 // Use DHT20 (Black)
+
+// #define USE_DHT11 // Use DHT11 (Blue)
+#define USE_DHT20 // Use DHT20 (Black)
 
 #ifdef USE_DHT11
   #define dht11Pin 3

--- a/send_temp_and_humi_with_soracom/send_temp_and_humi_with_soracom.ino
+++ b/send_temp_and_humi_with_soracom/send_temp_and_humi_with_soracom.ino
@@ -12,7 +12,7 @@
 #define INTERVAL_MS (60000)
 #define ENDPOINT "uni.soracom.io"
 #define SKETCH_NAME "send_temp_and_humi_with_soracom"
-#define VERSION "1.0"
+#define VERSION "1.1"
 
 /* for LTE-M Shield for Arduino */
 #define RX 10
@@ -33,8 +33,16 @@ U8X8_SSD1306_128X64_NONAME_HW_I2C u8x8(/* clock=*/ SCL, /* data=*/ SDA, /* reset
 #define U8X8_ENABLE_180_DEGREE_ROTATION 1
 
 #include <DHT.h>
-#define dht11Pin 3
-DHT dht(dht11Pin, DHT11);
+#define USE_DHT11 // Use DHT11 (Blue)
+//#define USE_DHT20 // Use DHT20 (Black)
+
+#ifdef USE_DHT11
+  #define dht11Pin 3
+  DHT dht(dht11Pin, DHT11);
+#endif
+#ifdef USE_DHT20
+  DHT dht(DHT20);
+#endif
 
 #define OLED_MAX_CHAR_LENGTH 16
 void drawText(U8X8* u8x8, const char* in_str, int width = OLED_MAX_CHAR_LENGTH);

--- a/temp_and_humi_with_oled/temp_and_humi_with_oled.ino
+++ b/temp_and_humi_with_oled/temp_and_humi_with_oled.ino
@@ -13,8 +13,17 @@ U8X8_SSD1306_128X64_NONAME_HW_I2C u8x8(/* clock=*/ SCL, /* data=*/ SDA, /* reset
 #define U8X8_ENABLE_180_DEGREE_ROTATION 1
 
 #include <DHT.h>
-#define dht11Pin 3
-DHT dht(dht11Pin, DHT11);
+
+#define USE_DHT11 // Use DHT11 (Blue)
+//#define USE_DHT20 // Use DHT20 (Black)
+
+#ifdef USE_DHT11
+  #define dht11Pin 3
+  DHT dht(dht11Pin, DHT11);
+#endif
+#ifdef USE_DHT20
+  DHT dht(DHT20);
+#endif
 
 void setup(void) {
   u8x8.begin();

--- a/temp_and_humi_with_oled/temp_and_humi_with_oled.ino
+++ b/temp_and_humi_with_oled/temp_and_humi_with_oled.ino
@@ -14,8 +14,8 @@ U8X8_SSD1306_128X64_NONAME_HW_I2C u8x8(/* clock=*/ SCL, /* data=*/ SDA, /* reset
 
 #include <DHT.h>
 
-#define USE_DHT11 // Use DHT11 (Blue)
-//#define USE_DHT20 // Use DHT20 (Black)
+// #define USE_DHT11 // Use DHT11 (Blue)
+#define USE_DHT20 // Use DHT20 (Black)
 
 #ifdef USE_DHT11
   #define dht11Pin 3


### PR DESCRIPTION
温湿度センサの変更（DHT11→DHT20）に対応するため、実装側で利用するセンサを切り替えられるように修正しました。
以下は、少し悩ましいポイントです。

**使うセンサの切り替え**

- どちらのセンサを初期状態で有効にするか
- 切り替えの方式（どちらかを使うことを既定として、ifdef-elseにするとかもありかなとは思っています）

**OLED出力の削除**

`send_multiple_sensor_data_with_soracom.ino` は、メモリ容量の兼ね合いで OLED への出力をシリアル出力する形で大幅に変更しました。